### PR TITLE
remove non-required post from the Host HTTP-header

### DIFF
--- a/src/ICMAD_scanner.py
+++ b/src/ICMAD_scanner.py
@@ -115,7 +115,7 @@ def _validate_resource_and_cache(host:str, port:int,
         logger.debug('Connection established %s:%s', host, port)
         logger.debug('Validating resource %s', r)
         payload = ('{method} {resource} HTTP/1.1\r\n'
-                   + 'Host: {host}:{port}\r\n\r\n')
+                   + 'Host: {host}\r\n\r\n')
         payload = payload.format(method=METHOD, resource=r, 
                                  host=host, port=port)
         payload = payload.encode()


### PR DESCRIPTION
In the HTTP-header `Host` ports are not required, even if you use HTTPS/TLS. 

_A Host header field must be sent in all HTTP/1.1 request messages. A 400 (Bad Request) status code may be sent to any HTTP/1.1 request message that lacks or contains more than one Host header field._
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host

HTTP gateways/reverse proxies which evaluate Host-Headers to choose the correct "route" may not forward you to the actual service which causes the PoC fail with an `IndexError`:

```
DEBUG - Crafting socket
DEBUG - Setting SSL context with verify mode False
/home/user/tools/onapsis_icmad_scanner/src/./ICMAD_scanner.py:37: DeprecationWarning: ssl.SSLContext() without protocol argument is deprecated.
context = ssl.SSLContext()
/home/user/tools/onapsis_icmad_scanner/src/./ICMAD_scanner.py:37: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
context = ssl.SSLContext()
DEBUG - Wraping socket with SSL
DEBUG - Connection established my-host:443
DEBUG - Validating resource /sap/admin/public/default.html?aaa
DEBUG - Payload sent
Traceback (most recent call last):
File "/home/user/tools/onapsis_icmad_scanner/src/./ICMAD_scanner.py", line 220, in <module>
main()
File "/home/user/tools/onapsis_icmad_scanner/src/./ICMAD_scanner.py", line 196, in main
resource = _validate_resource_and_cache(args.host, args.port,
File "/home/user/tools/onapsis_icmad_scanner/src/./ICMAD_scanner.py", line 129, in _validate_resource_and_cache
resp['responses'][0]['status_code'])
IndexError: list index out of range
```

Could you consider to remove the port in line 118 if it isn't critical for the PoC to actually trigger the vulnerability?